### PR TITLE
[HcomOps] Build kernels for c_comm_init and c_create_group

### DIFF
--- a/paddle/fluid/operators/collective/c_allreduce_op.h
+++ b/paddle/fluid/operators/collective/c_allreduce_op.h
@@ -131,8 +131,8 @@ class CAllReduceOpASCENDKernel : public framework::OpKernel<T> {
     // void* recvbuff = out->mutable_data<T>(place);
 
 
-    int rid = ctx.Attr<int>("ring_id");
-    auto comm = platform::HCCLCommContext::Instance().Get(rid, place);
+    //int rid = ctx.Attr<int>("ring_id");
+    auto comm = platform::HCCLCommContext::Instance().Get();
 
     aclrtStream stream = nullptr;
     if (ctx.Attr<bool>("use_calc_stream")) {

--- a/paddle/fluid/operators/collective/c_broadcast_op_npu.cc
+++ b/paddle/fluid/operators/collective/c_broadcast_op_npu.cc
@@ -32,9 +32,9 @@ class CBroadcastOpASCENDKernel : public framework::OpKernel<T> {
     int numel = x->numel();
     HcclDataType dtype = platform::ToHCCLDataType(x->type());
 
-    int rid = ctx.Attr<int>("ring_id");
+    //int rid = ctx.Attr<int>("ring_id");
     auto place = ctx.GetPlace();
-    auto comm = platform::HCCLCommContext::Instance().Get(rid, place);
+    auto comm = platform::HCCLCommContext::Instance().Get();
 
     aclrtStream stream = nullptr;
     if (ctx.Attr<bool>("use_calc_stream")) {

--- a/paddle/fluid/operators/collective/c_comm_init_op_npu.cc
+++ b/paddle/fluid/operators/collective/c_comm_init_op_npu.cc
@@ -40,7 +40,7 @@ class CCommInitOpNPU : public framework::OperatorBase {
 
   void RunImpl(const framework::Scope& scope,
                const platform::Place& place) const override {
-    string rank_table_file = Attr<string>("rank_table_file");
+    std::string rank_table_file = Attr<std::string>("rank_table_file");
     int rank_id = Attr<int>("rank_id");
     int device_id = Attr<int>("device_id");
     platform::HCCLCommContext::Instance().CreateHCCLComm(rank_table_file,
@@ -56,7 +56,7 @@ CCommInit operator on NPU
 
 Initialize collective communication context within this trainer
 )DOC");
-    AddAttr<string>("rank_table_file",
+    AddAttr<std::string>("rank_table_file",
         "(string) path to rank_table_file");
     AddAttr<int>("rank_id", "(int) world rank id of the process");
     AddAttr<int>("device_id", "(int) device id of the process/thread");

--- a/paddle/fluid/operators/collective/c_comm_init_op_npu.cc
+++ b/paddle/fluid/operators/collective/c_comm_init_op_npu.cc
@@ -1,0 +1,74 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#if defined(PADDLE_WITH_ASCEND_CL)
+#include "paddle/fluid/platform/collective_helper.h"
+#include "paddle/fluid/platform/hccl_helper.h"
+
+#include <string>
+
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/operators/npu_op_runner.h"
+
+namespace paddle {
+namespace framework {
+class Scope;
+}  // namespace framework
+}  // namespace paddle
+
+namespace paddle {
+namespace operators {
+
+class CCommInitOpNPU : public framework::OperatorBase {
+ public:
+  CCommInitOpNPU(const std::string& type,
+              const framework::VariableNameMap& inputs,
+              const framework::VariableNameMap& outputs,
+              const framework::AttributeMap& attrs)
+      : OperatorBase(type, inputs, outputs, attrs) {}
+
+  void RunImpl(const framework::Scope& scope,
+               const platform::Place& place) const override {
+    string rank_table_file = Attr<string>("rank_table_file");
+    int rank_id = Attr<int>("rank_id");
+    int device_id = Attr<int>("device_id");
+    platform::HCCLCommContext::Instance().CreateHCCLComm(rank_table_file,
+      rank_id, device_id);
+  }
+};
+
+class CCommInitOpNPUMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddComment(R"DOC(
+CCommInit operator on NPU
+
+Initialize collective communication context within this trainer
+)DOC");
+    AddAttr<string>("rank_table_file",
+        "(string) path to rank_table_file");
+    AddAttr<int>("rank_id", "(int) world rank id of the process");
+    AddAttr<int>("device_id", "(int) device id of the process/thread");
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+
+REGISTER_OPERATOR(c_comm_init, ops::CCommInitOpNPU,
+   ops::CCommInitOpNPUMaker);
+
+#endif

--- a/paddle/fluid/operators/collective/c_create_group_op_npu.cc
+++ b/paddle/fluid/operators/collective/c_create_group_op_npu.cc
@@ -1,0 +1,75 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#ifdef PADDLE_WITH_ASCEND_CL
+#include <hccl/hccl.h>
+#include <hccl/hccl_types.h>
+
+#include <string>
+
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/operators/npu_op_runner.h"
+
+namespace paddle {
+namespace framework {
+class Scope;
+}  // namespace framework
+}  // namespace paddle
+
+namespace paddle {
+namespace operators {
+
+class CCreateGroupOpNPU : public framework::OperatorBase {
+ public:
+  CCreateGroupOpNPU(const std::string& type,
+              const framework::VariableNameMap& inputs,
+              const framework::VariableNameMap& outputs,
+              const framework::AttributeMap& attrs)
+      : OperatorBase(type, inputs, outputs, attrs) {}
+
+  void RunImpl(const framework::Scope& scope,
+               const platform::Place& place) const override {
+    string group_name = Attr<string>("group_name");
+    int nranks = Attr<int>("nranks");
+    vector<int> rank_ids = Attr<vector<int>>("rank_ids");
+    platform::HCCLCommContext::Instance().CreateHCCLGroup(
+        group_name, nranks, rank_ids);
+  }
+};
+
+class CCreateGroupOpNPUMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddComment(R"DOC(
+CCreateGroup operator on NPU
+
+Create collective communication group on NPU
+)DOC");
+    AddAttr<string>("group_name",
+        "(string) name of the collective communication group");
+    AddAttr<int>("nranks", "(int) number of the group");
+    AddAttr<int>("rank_ids",
+                 "(list of int) The world rank id of the group members");
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+
+REGISTER_OPERATOR(c_create_group, ops::CCreateGroupOpNPU,
+    ops::CCreateGroupNPUMaker);
+
+#endif

--- a/paddle/fluid/platform/collective_helper.h
+++ b/paddle/fluid/platform/collective_helper.h
@@ -149,7 +149,7 @@ class NPUDeviceContext;
 
 class HCCLComm {
  public:
-  virtual string rank_table_file() const = "";
+  virtual std::string rank_table_file() const = 0;
   virtual int rank() const = 0;
   virtual int device_id() const = 0;
   virtual HcclComm comm() const = 0;
@@ -168,50 +168,16 @@ class HCCLCommContext {
 
   HCCLComm* CreateHCCLComm(const std::string& config_file, int rank, int dev_id);
 
-  void CreateHCCLGroup(const std::string& group_name, int nranks, const vector<int>& rank_ids);
-/*
-  // a latter comm with the same dev_id and the same ring_id
-  // will override the former
-  HCCLComm* AssignHCCLComm(HcclComm comm, int nranks, int rank, int dev_id,
-                           int ring_id = 0);
-
-  // retrieve a communicator by the ring id in multiprocessing mode
-  HCCLComm* Get(int ring_id) const {
-    PADDLE_ENFORCE_GT(
-        comm_map_.count(ring_id), 0,
-        platform::errors::InvalidArgument(
-            "Communicator in ring id %d has not been initialized.", ring_id));
-    PADDLE_ENFORCE_EQ(comm_map_.at(ring_id).size(), 1,
-                      platform::errors::InvalidArgument(
-                          "One device id should be specified to retrieve from "
-                          "multiple communicators."));
-    return comm_map_.at(ring_id).begin()->second.get();
-  }
-
-  // retrieve a communicator by the ring id and the device id
-  HCCLComm* Get(int ring_id, int dev_id) const {
-    PADDLE_ENFORCE_GT(
-        comm_map_.count(ring_id), 0,
-        platform::errors::InvalidArgument(
-            "Communicator of ring id %d has not been initialized.", ring_id));
-    PADDLE_ENFORCE_GT(
-        comm_map_.at(ring_id).count(dev_id), 0,
-        platform::errors::InvalidArgument(
-            "Communicator at device id %d has not been initialized in ring %d.",
-            dev_id, ring_id));
-    return comm_map_.at(ring_id).at(dev_id).get();
-  }
+  void CreateHCCLGroup(const std::string& group_name, int nranks, const std::vector<int>& rank_ids);
 
   // retrieve a communicator by the ring id and place
-  HCCLComm* Get(int ring_id, Place place) const {
-    return Get(ring_id, BOOST_GET_CONST(CUDAPlace, place).device);
+  HCCLComm* Get() const {
+    return comm_.get();
   }
-*/
  private:
   std::once_flag once_flag_;
   std::mutex comm_map_mutex_;
-  // rank id to dev-HCCLComm
-  // std::map<int, std::map<int, std::unique_ptr<HCCLComm>>> comm_map_;
+  std::unique_ptr<HCCLComm> comm_;
 
   void ReleaseHCCLComms();
 

--- a/paddle/fluid/platform/collective_helper.h
+++ b/paddle/fluid/platform/collective_helper.h
@@ -145,17 +145,16 @@ class NCCLCommContext {
 //
 // The HCCLComm instance is created and reversed in the HCCLCommContext
 // singleton with a global user specified group id.
-class ASCENDDeviceContext;
+class NPUDeviceContext;
 
 class HCCLComm {
  public:
-  virtual int ring_id() const = 0;
-  virtual int nranks() const = 0;
+  virtual string rank_table_file() const = "";
   virtual int rank() const = 0;
   virtual int device_id() const = 0;
   virtual HcclComm comm() const = 0;
   virtual aclrtStream stream() const = 0;
-  virtual ASCENDDeviceContext* dev_context() const = 0;
+  virtual NPUDeviceContext* dev_context() const = 0;
   virtual ~HCCLComm() = default;
 };
 
@@ -167,11 +166,10 @@ class HCCLCommContext {
     return comm_ctx;
   }
 
-  HCCLComm* CreateHCCLComm(std::string config_file, int nranks, int rank,
-                           int dev_id, int ring_id = 0);
+  HCCLComm* CreateHCCLComm(const std::string& config_file, int rank, int dev_id);
 
-  void CreateAllHCCLComms(const std::vector<int>& dev_ids, int ring_id = 0);
-
+  void CreateHCCLGroup(const std::string& group_name, int nranks, const vector<int>& rank_ids);
+/*
   // a latter comm with the same dev_id and the same ring_id
   // will override the former
   HCCLComm* AssignHCCLComm(HcclComm comm, int nranks, int rank, int dev_id,
@@ -208,12 +206,12 @@ class HCCLCommContext {
   HCCLComm* Get(int ring_id, Place place) const {
     return Get(ring_id, BOOST_GET_CONST(CUDAPlace, place).device);
   }
-
+*/
  private:
   std::once_flag once_flag_;
   std::mutex comm_map_mutex_;
-  // ring id to dev-HCCLComm
-  std::map<int, std::map<int, std::unique_ptr<HCCLComm>>> comm_map_;
+  // rank id to dev-HCCLComm
+  // std::map<int, std::map<int, std::unique_ptr<HCCLComm>>> comm_map_;
 
   void ReleaseHCCLComms();
 

--- a/paddle/fluid/platform/collective_helper_npu.cc
+++ b/paddle/fluid/platform/collective_helper_npu.cc
@@ -1,0 +1,137 @@
+//   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if defined(PADDLE_WITH_ASCEND_CL)
+#include "paddle/fluid/platform/collective_helper.h"
+#include <utility>
+
+namespace paddle {
+namespace platform {
+
+class HCCLCommImpl : public HCCLComm {
+ public:
+  void set_rank_table_file(std::string rank_table_file) { rank_table_file_ = rank_table_file; }
+  std::string rank_table_file() const override { return rank_table_file_; }
+
+  void set_rank(int rank) { rank_ = rank; }
+  int rank() const override { return rank_; }
+
+  void set_device_id(int device_id) { device_id_ = device_id; }
+  int device_id() const override { return device_id_; }
+
+  void set_comm(HcclComm comm) { comm_ = comm; }
+  HcclComm comm() const override { return comm_; }
+
+  aclrtStream stream() const override { return dev_ctx_->stream(); }
+
+  void set_dev_ctx(std::unique_ptr<NPUDeviceContext>&& dev_ctx) {
+    dev_ctx_ = std::move(dev_ctx);
+  }
+  NPUDeviceContext* dev_context() const override { return dev_ctx_.get(); }
+
+ private:
+  std::string rank_table_file_;
+  int rank_;
+  int device_id_;
+  HcclComm comm_;
+  std::unique_ptr<DeviceContext> dev_ctx_;
+};
+
+NCCLComm* HCCLCommContext::CreateHCCLComm(const std::string& rank_table_file,
+                                          int rank, int dev_id) {
+  PADDLE_ENFORCE_NOT_NULL(rank_table_file,
+                          platform::errors::InvalidArgument(
+                              "The rank table file should not be null."));
+  PADDLE_ENFORCE_GE(rank, 0,
+                    platform::errors::InvalidArgument(
+                        "Expected rank >= 0. But received rank is %d.", rank));
+  PADDLE_ENFORCE_GE(
+      dev_id, 0,
+      platform::errors::InvalidArgument(
+          "Expected dev_id >= 0. But received dev_id is %d.", dev_id));
+
+  HcclComm comm = nullptr;
+  PADDLE_ENFORCE_NPU_SUCCESS(aclrtSetDevice(dev_id));
+  PADDLE_ENFORCE_NPU_SUCCESS(
+      platform::dynload::HcclCommInitClusterInfo(rank_table_file, rank, &comm));
+
+  auto* comm_wrapper = AssignHCCLComm(comm, nranks, rank, dev_id, ring_id);
+
+  VLOG(1) << "hccl communicator of rank " << rank << " has been created on device " << dev_id;
+
+  std::call_once(once_flag_, []() {
+    std::atexit([]() { HCCLCommContext::Instance().ReleaseHCCLComms(); });
+  });
+
+  return comm_wrapper;
+}
+
+NCCLComm* HCCLCommContext::AssignHCCLComm(ncclComm_t comm, string rank_table_file, int rank, int dev_id) {
+  std::unique_ptr<NPUDeviceContext> dev_ctx(
+      new NPUDeviceContext(NPUPlace(dev_id)));
+
+  HCCLCommImpl* c = new HCCLCommImpl;
+  c->set_rank_table_file(rank_table_file);
+  c->set_rank(rank);
+  c->set_device_id(dev_id);
+  c->set_comm(comm);
+  c->set_dev_ctx(std::move(dev_ctx));
+
+  // comm_map_mutex_.lock();
+  // if (comm_map_.count(ring_id) == 0) {
+  //   comm_map_.emplace(ring_id, std::map<int, std::unique_ptr<NCCLComm>>());
+  // }
+  // auto& dev2comm = comm_map_[ring_id];
+
+  // dev2comm.emplace(dev_id, std::unique_ptr<NCCLComm>(c));
+  // comm_map_mutex_.unlock();
+
+  auto* dev_ctx = static_cast<platform::NPUDeviceContext*>(
+      platform::DeviceContextPool::Instance().Get(platform::NPUPlace(dev_id)));
+  dev_ctx->set_hccl_comm(comm);
+
+  // return comm_map_[ring_id][dev_id].get();
+  return c;
+}
+
+void HCCLCommContext::CreateHCCLGroup(const std::string& group_name, int nranks,
+  const vector<int>& rank_ids) {
+  PADDLE_ENFORCE_NOT_NULL(group_name,
+                          platform::errors::InvalidArgument(
+                              "The group name should not be null."));
+  PADDLE_ENFORCE_GT(nranks, 0,
+                    platform::errors::InvalidArgument(
+                        "Expected nranks > 0. But received nranks is %d.", nranks));
+  PADDLE_ENFORCE_NOT_NULL(rank_inds,
+                          platform::errors::InvalidArgument(
+                              "The rank ids should not be null."));
+
+  PADDLE_ENFORCE_NPU_SUCCESS(
+      platform::dynload::HcclCommInitClusterInfo(rank_table_file, rank, &comm));
+
+  VLOG(1) << "hccl group with name " << group_name << " has been created;
+}
+
+void HCCLCommContext::ReleaseHCCLComms() {
+  // for (auto& p : comm_map_) {
+  //   for (auto& q : p.second) {
+  //     q.second.reset();
+  //   }
+  // }
+}
+
+}  // namespace platform
+}  // namespace paddle
+
+#endif


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
1. Build kernels for c_comm_init and c_create_group
2. Implement HCCLCommContext